### PR TITLE
fix makefile so that css is copied when it changes, add .PHONY to clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,17 @@
 all: docs/src/lc3.c docs/src/lc3-alt.cpp docs/index.html
 
-docs/src/lc3.c docs/src/lc3-alt.cpp: index.lit main.css
+docs/src/lc3.c docs/src/lc3-alt.cpp: index.lit
 	lit --tangle $<
 	mv lc3.c docs/src/
 	mv lc3-alt.cpp docs/src/
 
-docs/index.html: index.lit
+docs/index.html: index.lit main.css
 	lit --weave $<
 	mv index.html docs/
-	cp main.css docs/main.css
 
+.PHONY:
 clean:
 	rm -f docs/src/lc3.c
 	rm -f docs/src/lc3-alt.cpp
 	rm -f docs/index.html
 	rm -f docs/main.css
-

--- a/docs/main.css
+++ b/docs/main.css
@@ -1,6 +1,0 @@
-img {
-    max-width: 100%;
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-}

--- a/docs/src/Makefile
+++ b/docs/src/Makefile
@@ -11,8 +11,7 @@ lc3-alt: lc3-alt.cpp
 lc3: lc3.c
 	${CC} ${C-FLAGS} $^ -o $@
 
+.PHONY:
 clean:
 	rm -f lc3
 	rm -f lc3-alt
-
-


### PR DESCRIPTION
Literate copies the contents of CSS files into a `<style>` element when weaving HTML, so there's no need to copy the CSS file. Instead, the document should be re-weaved when the CSS changes.