### PR TITLE
fix incorrect specificity of p styles

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -47,7 +47,7 @@ img {
     margin-right: auto;
 }
 
-p {
+p:not(.notp) {
     text-indent: 0;
     line-height: 1.3;
 }

--- a/main.css
+++ b/main.css
@@ -7,7 +7,7 @@ img {
     margin-right: auto;
 }
 
-p {
+p:not(.notp) {
     text-indent: 0;
     line-height: 1.3;
 }


### PR DESCRIPTION
At some point, I removed the `:not` pseudo-class from the text indentation style, but it ended up being necessary in order to have a higher specificity than the existing indentation style.