### PR TITLE
fix indentation of code blocks on MobileSafari

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -60,6 +60,10 @@ li {
     margin-bottom: 0.3rem;
 }
 
+pre {
+    -webkit-text-size-adjust: 100%;
+}
+
 /* Header Style */
 
 h4.noheading {

--- a/main.css
+++ b/main.css
@@ -20,6 +20,10 @@ li {
     margin-bottom: 0.3rem;
 }
 
+pre {
+    -webkit-text-size-adjust: 100%;
+}
+
 /* Header Style */
 
 h4.noheading {


### PR DESCRIPTION
Mobile Safari has a feature where it increases the font-size of non-mobile websites to make them more readable. However, this feature results in weird indentation in code blocks and actually makes them harder to read (in my opinion).

Disabling this feature makes it so the reader has to zoom in to read the code blocks, but I think this is still preferable to incorrect indentation, mismatched font-sizes, and messy line wrapping.