### PR TITLE
fix unitialized variable

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -687,7 +687,7 @@ char* far_data = "apple";
     /* destination register (DR) */
     uint16_t r0 = (instr &gt;&gt; 9) &amp; 0x7;
     /* PCoffset 9*/
-    uint16_t pc_offset = sign_extend(instr &amp; 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr &amp; 0x1FF, 9);
     /* add pc_offset to the current PC, look at that memory location to get the final address */
     reg[r0] = mem_read(mem_read(reg[R_PC] + pc_offset));
     update_flags(r0);
@@ -769,7 +769,7 @@ abort();
 <span class="codeblock_name">{BR <a href="index.html#1:7">7</a>}</span>
 <pre class="prettyprint lang-c">
 {
-    uint16_t pc_offset = sign_extend((instr) &amp; 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr &amp; 0x1FF, 9);
     uint16_t cond_flag = (instr &gt;&gt; 9) &amp; 0x7;
     if (cond_flag &amp; reg[R_COND])
     {
@@ -804,17 +804,16 @@ abort();
 <span class="codeblock_name">{JSR <a href="index.html#1:7">7</a>}</span>
 <pre class="prettyprint lang-c">
 {
-    uint16_t r1 = (instr &gt;&gt; 6) &amp; 0x7;
-    uint16_t long_pc_offset = sign_extend(instr &amp; 0x7ff, 11);
     uint16_t long_flag = (instr &gt;&gt; 11) &amp; 1;
-
     reg[R_R7] = reg[R_PC];
     if (long_flag)
     {
+        uint16_t long_pc_offset = sign_extend(instr &amp; 0x7FF, 11);
         reg[R_PC] += long_pc_offset;  /* JSR */
     }
     else
     {
+        uint16_t r1 = (instr &gt;&gt; 6) &amp; 0x7;
         reg[R_PC] = reg[r1]; /* JSRR */
     }
     break;
@@ -831,7 +830,7 @@ abort();
 <pre class="prettyprint lang-c">
 {
     uint16_t r0 = (instr &gt;&gt; 9) &amp; 0x7;
-    uint16_t pc_offset = sign_extend(instr &amp; 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr &amp; 0x1FF, 9);
     reg[r0] = mem_read(reg[R_PC] + pc_offset);
     update_flags(r0);
 }
@@ -864,7 +863,7 @@ abort();
 <pre class="prettyprint lang-c">
 {
     uint16_t r0 = (instr &gt;&gt; 9) &amp; 0x7;
-    uint16_t pc_offset = sign_extend(instr &amp; 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr &amp; 0x1FF, 9);
     reg[r0] = reg[R_PC] + pc_offset;
     update_flags(r0);
 }
@@ -880,7 +879,7 @@ abort();
 <pre class="prettyprint lang-c">
 {
     uint16_t r0 = (instr &gt;&gt; 9) &amp; 0x7;
-    uint16_t pc_offset = sign_extend(instr &amp; 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr &amp; 0x1FF, 9);
     mem_write(reg[R_PC] + pc_offset, reg[r0]);
 }
 </pre>
@@ -895,7 +894,7 @@ abort();
 <pre class="prettyprint lang-c">
 {
     uint16_t r0 = (instr &gt;&gt; 9) &amp; 0x7;
-    uint16_t pc_offset = sign_extend(instr &amp; 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr &amp; 0x1FF, 9);
     mem_write(mem_read(reg[R_PC] + pc_offset), reg[r0]);
 }
 </pre>
@@ -1546,18 +1545,25 @@ void ins(uint16_t instr)
     if (0x12F3 &amp; opbit) { r1 = (instr &gt;&gt; 6) &amp; 0x7; }
     if (0x0022 &amp; opbit)
     {
-        r2 = instr &amp; 0x7;
         imm_flag = (instr &gt;&gt; 5) &amp; 0x1;
-        imm5 = sign_extend((instr) &amp; 0x1F, 5);
+
+        if (imm_flag)
+        {
+            imm5 = sign_extend(instr &amp; 0x1F, 5);
+        }
+        else
+        {
+            r2 = instr &amp; 0x7;
+        }
     }
     if (0x00C0 &amp; opbit)
     {   // Base + offset
-        base_plus_off = reg[r1] + sign_extend(instr &amp; 0x3f, 6);
+        base_plus_off = reg[r1] + sign_extend(instr &amp; 0x3F, 6);
     }
     if (0x4C0D &amp; opbit)
     {
         // Indirect address
-        pc_plus_off = reg[R_PC] + sign_extend(instr &amp; 0x1ff, 9);
+        pc_plus_off = reg[R_PC] + sign_extend(instr &amp; 0x1FF, 9);
     }
     if (0x0001 &amp; opbit)
     {
@@ -1592,14 +1598,15 @@ void ins(uint16_t instr)
     if (0x0010 &amp; opbit)  // JSR
     {
         uint16_t long_flag = (instr &gt;&gt; 11) &amp; 1;
-        pc_plus_off = reg[R_PC] +  sign_extend(instr &amp; 0x7ff, 11);
         reg[R_R7] = reg[R_PC];
         if (long_flag)
         {
+            pc_plus_off = reg[R_PC] + sign_extend(instr &amp; 0x7FF, 11);
             reg[R_PC] = pc_plus_off;
         }
         else
         {
+            r1 = (instr &gt;&gt; 6) &amp; 0x7;
             reg[R_PC] = reg[r1];
         }
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1606,7 +1606,8 @@ void ins(uint16_t instr)
         }
         else
         {
-            r1 = (instr &gt;&gt; 6) &amp; 0x7;
+            // r1 = (instr &gt;&gt; 6) &amp; 0x7;
+            // Read earlier 
             reg[R_PC] = reg[r1];
         }
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1606,8 +1606,6 @@ void ins(uint16_t instr)
         }
         else
         {
-            // r1 = (instr &gt;&gt; 6) &amp; 0x7;
-            // Read earlier 
             reg[R_PC] = reg[r1];
         }
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1541,9 +1541,9 @@ void ins(uint16_t instr)
     uint16_t r0, r1, r2, imm5, imm_flag;
     uint16_t pc_plus_off, base_plus_off;
 
-    uint16_t opbit = (1 &lt;&lt; op);
+    constexpr uint16_t opbit = (1 &lt;&lt; op);
     if (0x4EEE &amp; opbit) { r0 = (instr &gt;&gt; 9) &amp; 0x7; }
-    if (0x12E3 &amp; opbit) { r1 = (instr &gt;&gt; 6) &amp; 0x7; }
+    if (0x12F3 &amp; opbit) { r1 = (instr &gt;&gt; 6) &amp; 0x7; }
     if (0x0022 &amp; opbit)
     {
         r2 = instr &amp; 0x7;

--- a/docs/src/lc3-alt-win.cpp
+++ b/docs/src/lc3-alt-win.cpp
@@ -278,7 +278,8 @@ void ins(uint16_t instr)
         }
         else
         {
-            r1 = (instr >> 6) & 0x7;
+            // r1 = (instr >> 6) & 0x7;
+            // Read earlier 
             reg[R_PC] = reg[r1];
         }
     }

--- a/docs/src/lc3-alt-win.cpp
+++ b/docs/src/lc3-alt-win.cpp
@@ -278,8 +278,6 @@ void ins(uint16_t instr)
         }
         else
         {
-            // r1 = (instr >> 6) & 0x7;
-            // Read earlier 
             reg[R_PC] = reg[r1];
         }
     }

--- a/docs/src/lc3-alt-win.cpp
+++ b/docs/src/lc3-alt-win.cpp
@@ -217,18 +217,25 @@ void ins(uint16_t instr)
     if (0x12F3 & opbit) { r1 = (instr >> 6) & 0x7; }
     if (0x0022 & opbit)
     {
-        r2 = instr & 0x7;
         imm_flag = (instr >> 5) & 0x1;
-        imm5 = sign_extend((instr) & 0x1F, 5);
+
+        if (imm_flag)
+        {
+            imm5 = sign_extend(instr & 0x1F, 5);
+        }
+        else
+        {
+            r2 = instr & 0x7;
+        }
     }
     if (0x00C0 & opbit)
     {   // Base + offset
-        base_plus_off = reg[r1] + sign_extend(instr & 0x3f, 6);
+        base_plus_off = reg[r1] + sign_extend(instr & 0x3F, 6);
     }
     if (0x4C0D & opbit)
     {
         // Indirect address
-        pc_plus_off = reg[R_PC] + sign_extend(instr & 0x1ff, 9);
+        pc_plus_off = reg[R_PC] + sign_extend(instr & 0x1FF, 9);
     }
     if (0x0001 & opbit)
     {
@@ -263,14 +270,15 @@ void ins(uint16_t instr)
     if (0x0010 & opbit)  // JSR
     {
         uint16_t long_flag = (instr >> 11) & 1;
-        pc_plus_off = reg[R_PC] +  sign_extend(instr & 0x7ff, 11);
         reg[R_R7] = reg[R_PC];
         if (long_flag)
         {
+            pc_plus_off = reg[R_PC] + sign_extend(instr & 0x7FF, 11);
             reg[R_PC] = pc_plus_off;
         }
         else
         {
+            r1 = (instr >> 6) & 0x7;
             reg[R_PC] = reg[r1];
         }
     }

--- a/docs/src/lc3-alt-win.cpp
+++ b/docs/src/lc3-alt-win.cpp
@@ -212,9 +212,9 @@ void ins(uint16_t instr)
     uint16_t r0, r1, r2, imm5, imm_flag;
     uint16_t pc_plus_off, base_plus_off;
 
-    uint16_t opbit = (1 << op);
+    constexpr uint16_t opbit = (1 << op);
     if (0x4EEE & opbit) { r0 = (instr >> 9) & 0x7; }
-    if (0x12E3 & opbit) { r1 = (instr >> 6) & 0x7; }
+    if (0x12F3 & opbit) { r1 = (instr >> 6) & 0x7; }
     if (0x0022 & opbit)
     {
         r2 = instr & 0x7;

--- a/docs/src/lc3-alt.cpp
+++ b/docs/src/lc3-alt.cpp
@@ -225,18 +225,25 @@ void ins(uint16_t instr)
     if (0x12F3 & opbit) { r1 = (instr >> 6) & 0x7; }
     if (0x0022 & opbit)
     {
-        r2 = instr & 0x7;
         imm_flag = (instr >> 5) & 0x1;
-        imm5 = sign_extend((instr) & 0x1F, 5);
+
+        if (imm_flag)
+        {
+            imm5 = sign_extend(instr & 0x1F, 5);
+        }
+        else
+        {
+            r2 = instr & 0x7;
+        }
     }
     if (0x00C0 & opbit)
     {   // Base + offset
-        base_plus_off = reg[r1] + sign_extend(instr & 0x3f, 6);
+        base_plus_off = reg[r1] + sign_extend(instr & 0x3F, 6);
     }
     if (0x4C0D & opbit)
     {
         // Indirect address
-        pc_plus_off = reg[R_PC] + sign_extend(instr & 0x1ff, 9);
+        pc_plus_off = reg[R_PC] + sign_extend(instr & 0x1FF, 9);
     }
     if (0x0001 & opbit)
     {
@@ -271,14 +278,15 @@ void ins(uint16_t instr)
     if (0x0010 & opbit)  // JSR
     {
         uint16_t long_flag = (instr >> 11) & 1;
-        pc_plus_off = reg[R_PC] +  sign_extend(instr & 0x7ff, 11);
         reg[R_R7] = reg[R_PC];
         if (long_flag)
         {
+            pc_plus_off = reg[R_PC] + sign_extend(instr & 0x7FF, 11);
             reg[R_PC] = pc_plus_off;
         }
         else
         {
+            r1 = (instr >> 6) & 0x7;
             reg[R_PC] = reg[r1];
         }
     }

--- a/docs/src/lc3-alt.cpp
+++ b/docs/src/lc3-alt.cpp
@@ -220,9 +220,9 @@ void ins(uint16_t instr)
     uint16_t r0, r1, r2, imm5, imm_flag;
     uint16_t pc_plus_off, base_plus_off;
 
-    uint16_t opbit = (1 << op);
+    constexpr uint16_t opbit = (1 << op);
     if (0x4EEE & opbit) { r0 = (instr >> 9) & 0x7; }
-    if (0x12E3 & opbit) { r1 = (instr >> 6) & 0x7; }
+    if (0x12F3 & opbit) { r1 = (instr >> 6) & 0x7; }
     if (0x0022 & opbit)
     {
         r2 = instr & 0x7;

--- a/docs/src/lc3-alt.cpp
+++ b/docs/src/lc3-alt.cpp
@@ -286,8 +286,6 @@ void ins(uint16_t instr)
         }
         else
         {
-            // r1 = (instr >> 6) & 0x7;
-            // Read earlier 
             reg[R_PC] = reg[r1];
         }
     }

--- a/docs/src/lc3-alt.cpp
+++ b/docs/src/lc3-alt.cpp
@@ -286,7 +286,8 @@ void ins(uint16_t instr)
         }
         else
         {
-            r1 = (instr >> 6) & 0x7;
+            // r1 = (instr >> 6) & 0x7;
+            // Read earlier 
             reg[R_PC] = reg[r1];
         }
     }

--- a/docs/src/lc3-win.c
+++ b/docs/src/lc3-win.c
@@ -304,7 +304,7 @@ int main(int argc, const char* argv[])
             case OP_BR:
                 /* BR */
                 {
-                    uint16_t pc_offset = sign_extend((instr) & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     uint16_t cond_flag = (instr >> 9) & 0x7;
                     if (cond_flag & reg[R_COND])
                     {
@@ -325,17 +325,16 @@ int main(int argc, const char* argv[])
             case OP_JSR:
                 /* JSR */
                 {
-                    uint16_t r1 = (instr >> 6) & 0x7;
-                    uint16_t long_pc_offset = sign_extend(instr & 0x7ff, 11);
                     uint16_t long_flag = (instr >> 11) & 1;
-                
                     reg[R_R7] = reg[R_PC];
                     if (long_flag)
                     {
+                        uint16_t long_pc_offset = sign_extend(instr & 0x7FF, 11);
                         reg[R_PC] += long_pc_offset;  /* JSR */
                     }
                     else
                     {
+                        uint16_t r1 = (instr >> 6) & 0x7;
                         reg[R_PC] = reg[r1]; /* JSRR */
                     }
                     break;
@@ -346,7 +345,7 @@ int main(int argc, const char* argv[])
                 /* LD */
                 {
                     uint16_t r0 = (instr >> 9) & 0x7;
-                    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     reg[r0] = mem_read(reg[R_PC] + pc_offset);
                     update_flags(r0);
                 }
@@ -358,7 +357,7 @@ int main(int argc, const char* argv[])
                     /* destination register (DR) */
                     uint16_t r0 = (instr >> 9) & 0x7;
                     /* PCoffset 9*/
-                    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     /* add pc_offset to the current PC, look at that memory location to get the final address */
                     reg[r0] = mem_read(mem_read(reg[R_PC] + pc_offset));
                     update_flags(r0);
@@ -380,7 +379,7 @@ int main(int argc, const char* argv[])
                 /* LEA */
                 {
                     uint16_t r0 = (instr >> 9) & 0x7;
-                    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     reg[r0] = reg[R_PC] + pc_offset;
                     update_flags(r0);
                 }
@@ -390,7 +389,7 @@ int main(int argc, const char* argv[])
                 /* ST */
                 {
                     uint16_t r0 = (instr >> 9) & 0x7;
-                    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     mem_write(reg[R_PC] + pc_offset, reg[r0]);
                 }
 
@@ -399,7 +398,7 @@ int main(int argc, const char* argv[])
                 /* STI */
                 {
                     uint16_t r0 = (instr >> 9) & 0x7;
-                    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     mem_write(mem_read(reg[R_PC] + pc_offset), reg[r0]);
                 }
 

--- a/docs/src/lc3.c
+++ b/docs/src/lc3.c
@@ -311,7 +311,7 @@ int main(int argc, const char* argv[])
             case OP_BR:
                 /* BR */
                 {
-                    uint16_t pc_offset = sign_extend((instr) & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     uint16_t cond_flag = (instr >> 9) & 0x7;
                     if (cond_flag & reg[R_COND])
                     {
@@ -332,17 +332,16 @@ int main(int argc, const char* argv[])
             case OP_JSR:
                 /* JSR */
                 {
-                    uint16_t r1 = (instr >> 6) & 0x7;
-                    uint16_t long_pc_offset = sign_extend(instr & 0x7ff, 11);
                     uint16_t long_flag = (instr >> 11) & 1;
-                
                     reg[R_R7] = reg[R_PC];
                     if (long_flag)
                     {
+                        uint16_t long_pc_offset = sign_extend(instr & 0x7FF, 11);
                         reg[R_PC] += long_pc_offset;  /* JSR */
                     }
                     else
                     {
+                        uint16_t r1 = (instr >> 6) & 0x7;
                         reg[R_PC] = reg[r1]; /* JSRR */
                     }
                     break;
@@ -353,7 +352,7 @@ int main(int argc, const char* argv[])
                 /* LD */
                 {
                     uint16_t r0 = (instr >> 9) & 0x7;
-                    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     reg[r0] = mem_read(reg[R_PC] + pc_offset);
                     update_flags(r0);
                 }
@@ -365,7 +364,7 @@ int main(int argc, const char* argv[])
                     /* destination register (DR) */
                     uint16_t r0 = (instr >> 9) & 0x7;
                     /* PCoffset 9*/
-                    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     /* add pc_offset to the current PC, look at that memory location to get the final address */
                     reg[r0] = mem_read(mem_read(reg[R_PC] + pc_offset));
                     update_flags(r0);
@@ -387,7 +386,7 @@ int main(int argc, const char* argv[])
                 /* LEA */
                 {
                     uint16_t r0 = (instr >> 9) & 0x7;
-                    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     reg[r0] = reg[R_PC] + pc_offset;
                     update_flags(r0);
                 }
@@ -397,7 +396,7 @@ int main(int argc, const char* argv[])
                 /* ST */
                 {
                     uint16_t r0 = (instr >> 9) & 0x7;
-                    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     mem_write(reg[R_PC] + pc_offset, reg[r0]);
                 }
 
@@ -406,7 +405,7 @@ int main(int argc, const char* argv[])
                 /* STI */
                 {
                     uint16_t r0 = (instr >> 9) & 0x7;
-                    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+                    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
                     mem_write(mem_read(reg[R_PC] + pc_offset), reg[r0]);
                 }
 

--- a/index.lit
+++ b/index.lit
@@ -1096,9 +1096,9 @@ void ins(uint16_t instr)
     uint16_t r0, r1, r2, imm5, imm_flag;
     uint16_t pc_plus_off, base_plus_off;
 
-    uint16_t opbit = (1 << op);
+    constexpr uint16_t opbit = (1 << op);
     if (0x4EEE & opbit) { r0 = (instr >> 9) & 0x7; }
-    if (0x12E3 & opbit) { r1 = (instr >> 6) & 0x7; }
+    if (0x12F3 & opbit) { r1 = (instr >> 6) & 0x7; }
     if (0x0022 & opbit)
     {
         r2 = instr & 0x7;

--- a/index.lit
+++ b/index.lit
@@ -474,7 +474,7 @@ Here is the code for this case: (`mem_read` will be discussed in a later section
     /* destination register (DR) */
     uint16_t r0 = (instr >> 9) & 0x7;
     /* PCoffset 9*/
-    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
     /* add pc_offset to the current PC, look at that memory location to get the final address */
     reg[r0] = mem_read(mem_read(reg[R_PC] + pc_offset));
     update_flags(r0);
@@ -531,7 +531,7 @@ abort();
 ### Branch
 --- BR
 {
-    uint16_t pc_offset = sign_extend((instr) & 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
     uint16_t cond_flag = (instr >> 9) & 0x7;
     if (cond_flag & reg[R_COND])
     {
@@ -552,17 +552,16 @@ abort();
 ### Jump Register
 --- JSR
 {
-    uint16_t r1 = (instr >> 6) & 0x7;
-    uint16_t long_pc_offset = sign_extend(instr & 0x7ff, 11);
     uint16_t long_flag = (instr >> 11) & 1;
-
     reg[R_R7] = reg[R_PC];
     if (long_flag)
     {
+        uint16_t long_pc_offset = sign_extend(instr & 0x7FF, 11);
         reg[R_PC] += long_pc_offset;  /* JSR */
     }
     else
     {
+        uint16_t r1 = (instr >> 6) & 0x7;
         reg[R_PC] = reg[r1]; /* JSRR */
     }
     break;
@@ -572,7 +571,7 @@ abort();
 --- LD
 {
     uint16_t r0 = (instr >> 9) & 0x7;
-    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
     reg[r0] = mem_read(reg[R_PC] + pc_offset);
     update_flags(r0);
 }
@@ -592,7 +591,7 @@ abort();
 --- LEA
 {
     uint16_t r0 = (instr >> 9) & 0x7;
-    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
     reg[r0] = reg[R_PC] + pc_offset;
     update_flags(r0);
 }
@@ -601,7 +600,7 @@ abort();
 --- ST
 {
     uint16_t r0 = (instr >> 9) & 0x7;
-    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
     mem_write(reg[R_PC] + pc_offset, reg[r0]);
 }
 ---
@@ -609,7 +608,7 @@ abort();
 --- STI
 {
     uint16_t r0 = (instr >> 9) & 0x7;
-    uint16_t pc_offset = sign_extend(instr & 0x1ff, 9);
+    uint16_t pc_offset = sign_extend(instr & 0x1FF, 9);
     mem_write(mem_read(reg[R_PC] + pc_offset), reg[r0]);
 }
 ---
@@ -1101,18 +1100,25 @@ void ins(uint16_t instr)
     if (0x12F3 & opbit) { r1 = (instr >> 6) & 0x7; }
     if (0x0022 & opbit)
     {
-        r2 = instr & 0x7;
         imm_flag = (instr >> 5) & 0x1;
-        imm5 = sign_extend((instr) & 0x1F, 5);
+
+        if (imm_flag)
+        {
+            imm5 = sign_extend(instr & 0x1F, 5);
+        }
+        else
+        {
+            r2 = instr & 0x7;
+        }
     }
     if (0x00C0 & opbit)
     {   // Base + offset
-        base_plus_off = reg[r1] + sign_extend(instr & 0x3f, 6);
+        base_plus_off = reg[r1] + sign_extend(instr & 0x3F, 6);
     }
     if (0x4C0D & opbit)
     {
         // Indirect address
-        pc_plus_off = reg[R_PC] + sign_extend(instr & 0x1ff, 9);
+        pc_plus_off = reg[R_PC] + sign_extend(instr & 0x1FF, 9);
     }
     if (0x0001 & opbit)
     {
@@ -1147,14 +1153,15 @@ void ins(uint16_t instr)
     if (0x0010 & opbit)  // JSR
     {
         uint16_t long_flag = (instr >> 11) & 1;
-        pc_plus_off = reg[R_PC] +  sign_extend(instr & 0x7ff, 11);
         reg[R_R7] = reg[R_PC];
         if (long_flag)
         {
+            pc_plus_off = reg[R_PC] + sign_extend(instr & 0x7FF, 11);
             reg[R_PC] = pc_plus_off;
         }
         else
         {
+            r1 = (instr >> 6) & 0x7;
             reg[R_PC] = reg[r1];
         }
     }

--- a/index.lit
+++ b/index.lit
@@ -1161,8 +1161,6 @@ void ins(uint16_t instr)
         }
         else
         {
-            // r1 = (instr >> 6) & 0x7;
-            // Read earlier 
             reg[R_PC] = reg[r1];
         }
     }

--- a/index.lit
+++ b/index.lit
@@ -1161,7 +1161,8 @@ void ins(uint16_t instr)
         }
         else
         {
-            r1 = (instr >> 6) & 0x7;
+            // r1 = (instr >> 6) & 0x7;
+            // Read earlier 
             reg[R_PC] = reg[r1];
         }
     }


### PR DESCRIPTION
It is called one more time than it might need (depending on the JSR mode), but that depends on the instruction input, not the op code used for compile time generation.