### PR TITLE
Fix a few issues with input traps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.out
 *.obj
 *.exe
+*.dSYM
 
 lc3
 lc3-alt

--- a/docs/index.html
+++ b/docs/index.html
@@ -391,6 +391,9 @@ int main(int argc, const char* argv[])
 <span class="nocode pln">    {Load Arguments, <a href="index.html#1:5">5</a>}</span>
 <span class="nocode pln">    {Setup, <a href="index.html#1:12">12</a>}</span>
 
+    /* since exactly one condition flag should be set at any given time, set the Z flag */
+    reg[R_COND] = FL_ZRO;
+
     /* set the PC to starting position */
     /* 0x3000 is the default */
     enum { PC_START = 0x3000 };
@@ -956,7 +959,7 @@ The CPU executes the procedure's instructions, and when it is complete, the PC i
 <p>There is no specification for <em>how</em> trap routines must be implemented, only what they are supposed to do.
 In our VM, we are going to do things slightly differently by writing them in C.
 When a trap code is invoked, a C function will be called. When it is completed, execution will return to the instructions.
-(If you are curious about trap codes in assembly, see <a href="https://github.com/rpendleton/lc3sim-c">Ryan's implementation</a>.) 
+(If you are curious about trap codes in assembly, see <a href="https://github.com/rpendleton/lc3sim-c">Ryan's implementation</a>.)
 </p>
 <p>Even though the trap routines can be written in assembly and this is what a physical LC-3 computer would do, it isn't the best fit for a VM. Instead of writing our own primitive I/O routines, we can take advantage of the ones available on our OS. This will make the VM run better on our computers, simplify the code, and provide a higher level of abstraction for portability.
 </p>
@@ -1707,7 +1710,7 @@ we decided to utilize GitHub tags to organize them.
 <p>To list your own project, just make sure it is tagged with the GitHub topic <code>lc3</code>.
 If your language is missing, feel free to submit a pull request.
 </p>
-<p>Special thanks to <a href="https://github.com/inkydragon">inkydragon</a> for contributing Windows platform support. 
+<p>Special thanks to <a href="https://github.com/inkydragon">inkydragon</a> for contributing Windows platform support.
 </p>
 <p>Want to contribute? We need help with an integration test.
 This is a good <a href="https://github.com/justinmeiners/lc3-vm/issues/13">first issue</a> to learn from.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1044,6 +1044,7 @@ switch (instr &amp; 0xFF)
 <pre class="prettyprint lang-c">
 /* read a single ASCII char */
 reg[R_R0] = (uint16_t)getchar();
+update_flags(R_R0);
 </pre>
 
 
@@ -1073,6 +1074,7 @@ fflush(stdout);
     char c = getchar();
     putc(c, stdout);
     reg[R_R0] = (uint16_t)c;
+    update_flags(R_R0);
 }
 </pre>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1073,6 +1073,7 @@ fflush(stdout);
     printf("Enter a character: ");
     char c = getchar();
     putc(c, stdout);
+    fflush(stdout);
     reg[R_R0] = (uint16_t)c;
     update_flags(R_R0);
 }

--- a/docs/src/lc3-alt-win.cpp
+++ b/docs/src/lc3-alt-win.cpp
@@ -327,6 +327,7 @@ void ins(uint16_t instr)
                      printf("Enter a character: ");
                      char c = getchar();
                      putc(c, stdout);
+                     fflush(stdout);
                      reg[R_R0] = (uint16_t)c;
                      update_flags(R_R0);
                  }

--- a/docs/src/lc3-alt-win.cpp
+++ b/docs/src/lc3-alt-win.cpp
@@ -298,6 +298,7 @@ void ins(uint16_t instr)
                  /* TRAP GETC */
                  /* read a single ASCII char */
                  reg[R_R0] = (uint16_t)getchar();
+                 update_flags(R_R0);
 
                  break;
              case TRAP_OUT:
@@ -327,6 +328,7 @@ void ins(uint16_t instr)
                      char c = getchar();
                      putc(c, stdout);
                      reg[R_R0] = (uint16_t)c;
+                     update_flags(R_R0);
                  }
 
                  break;

--- a/docs/src/lc3-alt.cpp
+++ b/docs/src/lc3-alt.cpp
@@ -407,6 +407,8 @@ int main(int argc, const char* argv[])
     disable_input_buffering();
 
 
+    reg[R_COND] = FL_ZRO;
+
     enum { PC_START = 0x3000 };
     reg[R_PC] = PC_START;
 

--- a/docs/src/lc3-alt.cpp
+++ b/docs/src/lc3-alt.cpp
@@ -306,6 +306,7 @@ void ins(uint16_t instr)
                  /* TRAP GETC */
                  /* read a single ASCII char */
                  reg[R_R0] = (uint16_t)getchar();
+                 update_flags(R_R0);
 
                  break;
              case TRAP_OUT:
@@ -335,6 +336,7 @@ void ins(uint16_t instr)
                      char c = getchar();
                      putc(c, stdout);
                      reg[R_R0] = (uint16_t)c;
+                     update_flags(R_R0);
                  }
 
                  break;

--- a/docs/src/lc3-alt.cpp
+++ b/docs/src/lc3-alt.cpp
@@ -335,6 +335,7 @@ void ins(uint16_t instr)
                      printf("Enter a character: ");
                      char c = getchar();
                      putc(c, stdout);
+                     fflush(stdout);
                      reg[R_R0] = (uint16_t)c;
                      update_flags(R_R0);
                  }

--- a/docs/src/lc3-win.c
+++ b/docs/src/lc3-win.c
@@ -421,6 +421,7 @@ int main(int argc, const char* argv[])
                         /* TRAP GETC */
                         /* read a single ASCII char */
                         reg[R_R0] = (uint16_t)getchar();
+                        update_flags(R_R0);
 
                         break;
                     case TRAP_OUT:
@@ -450,6 +451,7 @@ int main(int argc, const char* argv[])
                             char c = getchar();
                             putc(c, stdout);
                             reg[R_R0] = (uint16_t)c;
+                            update_flags(R_R0);
                         }
 
                         break;

--- a/docs/src/lc3-win.c
+++ b/docs/src/lc3-win.c
@@ -230,6 +230,9 @@ int main(int argc, const char* argv[])
     disable_input_buffering();
 
 
+    /* since exactly one condition flag should be set at any given time, set the Z flag */
+    reg[R_COND] = FL_ZRO;
+
     /* set the PC to starting position */
     /* 0x3000 is the default */
     enum { PC_START = 0x3000 };

--- a/docs/src/lc3-win.c
+++ b/docs/src/lc3-win.c
@@ -450,6 +450,7 @@ int main(int argc, const char* argv[])
                             printf("Enter a character: ");
                             char c = getchar();
                             putc(c, stdout);
+                            fflush(stdout);
                             reg[R_R0] = (uint16_t)c;
                             update_flags(R_R0);
                         }

--- a/docs/src/lc3.c
+++ b/docs/src/lc3.c
@@ -457,6 +457,7 @@ int main(int argc, const char* argv[])
                             printf("Enter a character: ");
                             char c = getchar();
                             putc(c, stdout);
+                            fflush(stdout);
                             reg[R_R0] = (uint16_t)c;
                             update_flags(R_R0);
                         }

--- a/docs/src/lc3.c
+++ b/docs/src/lc3.c
@@ -428,6 +428,7 @@ int main(int argc, const char* argv[])
                         /* TRAP GETC */
                         /* read a single ASCII char */
                         reg[R_R0] = (uint16_t)getchar();
+                        update_flags(R_R0);
 
                         break;
                     case TRAP_OUT:
@@ -457,6 +458,7 @@ int main(int argc, const char* argv[])
                             char c = getchar();
                             putc(c, stdout);
                             reg[R_R0] = (uint16_t)c;
+                            update_flags(R_R0);
                         }
 
                         break;

--- a/docs/src/lc3.c
+++ b/docs/src/lc3.c
@@ -237,6 +237,9 @@ int main(int argc, const char* argv[])
     disable_input_buffering();
 
 
+    /* since exactly one condition flag should be set at any given time, set the Z flag */
+    reg[R_COND] = FL_ZRO;
+
     /* set the PC to starting position */
     /* 0x3000 is the default */
     enum { PC_START = 0x3000 };

--- a/index.lit
+++ b/index.lit
@@ -738,6 +738,7 @@ Prompt for Input Character
     printf("Enter a character: ");
     char c = getchar();
     putc(c, stdout);
+    fflush(stdout);
     reg[R_R0] = (uint16_t)c;
     update_flags(R_R0);
 }

--- a/index.lit
+++ b/index.lit
@@ -235,6 +235,9 @@ int main(int argc, const char* argv[])
     @{Load Arguments}
     @{Setup}
 
+    /* since exactly one condition flag should be set at any given time, set the Z flag */
+    reg[R_COND] = FL_ZRO;
+
     /* set the PC to starting position */
     /* 0x3000 is the default */
     enum { PC_START = 0x3000 };
@@ -653,7 +656,7 @@ The CPU executes the procedure's instructions, and when it is complete, the PC i
 There is no specification for *how* trap routines must be implemented, only what they are supposed to do.
 In our VM, we are going to do things slightly differently by writing them in C.
 When a trap code is invoked, a C function will be called. When it is completed, execution will return to the instructions.
-(If you are curious about trap codes in assembly, see [Ryan's implementation](https://github.com/rpendleton/lc3sim-c).) 
+(If you are curious about trap codes in assembly, see [Ryan's implementation](https://github.com/rpendleton/lc3sim-c).)
 
 Even though the trap routines can be written in assembly and this is what a physical LC-3 computer would do, it isn't the best fit for a VM. Instead of writing our own primitive I/O routines, we can take advantage of the ones available on our OS. This will make the VM run better on our computers, simplify the code, and provide a higher level of abstraction for portability.
 
@@ -1238,6 +1241,8 @@ int main(int argc, const char* argv[])
     @{Load Arguments}
     @{Setup}
 
+    reg[R_COND] = FL_ZRO;
+
     enum { PC_START = 0x3000 };
     reg[R_PC] = PC_START;
 
@@ -1324,8 +1329,7 @@ we decided to utilize GitHub tags to organize them.
 To list your own project, just make sure it is tagged with the GitHub topic `lc3`.
 If your language is missing, feel free to submit a pull request.
 
-Special thanks to [inkydragon](https://github.com/inkydragon) for contributing Windows platform support. 
+Special thanks to [inkydragon](https://github.com/inkydragon) for contributing Windows platform support.
 
 Want to contribute? We need help with an integration test.
 This is a good [first issue](https://github.com/justinmeiners/lc3-vm/issues/13) to learn from.
-

--- a/index.lit
+++ b/index.lit
@@ -723,6 +723,7 @@ Input Character
 --- TRAP GETC
 /* read a single ASCII char */
 reg[R_R0] = (uint16_t)getchar();
+update_flags(R_R0);
 ---
 
 Output Character
@@ -738,6 +739,7 @@ Prompt for Input Character
     char c = getchar();
     putc(c, stdout);
     reg[R_R0] = (uint16_t)c;
+    update_flags(R_R0);
 }
 ---
 


### PR DESCRIPTION
This PR fixes #43 and fixes #44.

I checked the entire index.lit file for places that we output characters, and it looks like this was the only one that was missing a call to `fflush`.

I also checked for anywhere that we modified registers, and aside from the PC register, it looks like these two were the only missing calls to `update_flags` as well.