### PR TITLE
Fix memory locations array size

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@ The final code was created by <a href="https://github.com/justinmeiners/srcweave
 <span class="block-header">
 <strong class="block-title"><em><a id="bMemory_Storage:55" href="#bMemory_Storage:55">Memory Storage</a></em></strong></span>
 <pre class="prettyprint"><code class="">/* 65536 locations */
-uint16_t memory[UINT16_MAX];
+uint16_t memory[UINT16_MAX + 1];
 </code></pre>
 <p class="block-usages"><small>Used by <a href="#b/lc3.c:869" title="index.lit:870 /lc3.c">1</a> <span title="index.lit:1026 /lc3-win.c">2</span> <span title="index.lit:1205 /lc3-alt.cpp">3</span> <span title="index.lit:1252 /lc3-alt-win.cpp">4</span> </small></p></div>
 

--- a/docs/src/lc3-alt-win.cpp
+++ b/docs/src/lc3-alt-win.cpp
@@ -63,7 +63,7 @@ enum
 };
 
 /* 65536 locations */
-uint16_t memory[UINT16_MAX];
+uint16_t memory[UINT16_MAX + 1];
 uint16_t reg[R_COUNT];
 
 uint16_t sign_extend(uint16_t x, int bit_count)

--- a/docs/src/lc3-alt.cpp
+++ b/docs/src/lc3-alt.cpp
@@ -68,7 +68,7 @@ enum
 };
 
 /* 65536 locations */
-uint16_t memory[UINT16_MAX];
+uint16_t memory[UINT16_MAX + 1];
 uint16_t reg[R_COUNT];
 
 uint16_t sign_extend(uint16_t x, int bit_count)

--- a/docs/src/lc3-win.c
+++ b/docs/src/lc3-win.c
@@ -63,7 +63,7 @@ enum
 };
 
 /* 65536 locations */
-uint16_t memory[UINT16_MAX];
+uint16_t memory[UINT16_MAX + 1];
 uint16_t reg[R_COUNT];
 
 uint16_t sign_extend(uint16_t x, int bit_count)

--- a/docs/src/lc3.c
+++ b/docs/src/lc3.c
@@ -67,7 +67,7 @@ enum
 };
 
 /* 65536 locations */
-uint16_t memory[UINT16_MAX];
+uint16_t memory[UINT16_MAX + 1];
 uint16_t reg[R_COUNT];
 
 uint16_t sign_extend(uint16_t x, int bit_count)

--- a/index.lit
+++ b/index.lit
@@ -54,7 +54,7 @@ The LC-3 has 65,536 memory locations (the maximum that is addressable by a 16-bi
 
 --- Memory Storage
 /* 65536 locations */
-uint16_t memory[UINT16_MAX];
+uint16_t memory[UINT16_MAX + 1];
 ---
 
 ### Registers


### PR DESCRIPTION
# Summary

These changes ensure that there are precisely `65536` elements (or _memory locations_) in the `memory` array, which corresponds with the tutorial descriptions and code comments. The issue is described in more detail below:

# The problem

The `UINT16_MAX` macro is used in multiple places and assumed to equal the value 65536:

```c
/* 65536 locations */
uint16_t memory[UINT16_MAX];
```

However, according to the POSIX standard regarding [limits for specified-width integer types](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/stdint.h.html#tag_13_47_03_02), `UINTN_MAX`-style macros provide:

> Maximum values of exact-width unsigned integer types:
>
> {UINTN_MAX}
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Exactly 2^N -1

In the case of the code example above, the use of `UINT16_MAX` would yield an array with `2^16 - 1` (`65535`) elements, meaning it introduces the potential for [off-by-one](https://en.wikipedia.org/wiki/Off-by-one_error) errors should we assume there are `65536` elements available elsewhere. The number of array elements also differs from the number specified in the code comment and tutorial description.

# Failing test

```c
#include <assert.h>
#include <stdint.h>

int
main(void) {
    /* 65536 locations */
    uint16_t memory[UINT16_MAX];
    assert(sizeof(memory) / sizeof(memory[0]) == 65536);
}
```

# Passing test

With the expression `UINT16_MAX + 1`:

```c
#include <assert.h>
#include <stdint.h>

int
main(void) {
    /* 65536 locations */
    uint16_t memory[UINT16_MAX + 1];
    assert(sizeof(memory) / sizeof(memory[0]) == 65536);
}
```
