### PR TITLE
Fix a slight bug with JSRR - JSRR R7.

### DIFF
--- a/index.lit
+++ b/index.lit
@@ -545,7 +545,7 @@ abort();
 --- JSR
 {
     uint16_t long_flag = (instr >> 11) & 1;
-    reg[R_R7] = reg[R_PC];
+    uint16_t temp = reg[R_PC];
     if (long_flag)
     {
         uint16_t long_pc_offset = sign_extend(instr & 0x7FF, 11);
@@ -556,6 +556,7 @@ abort();
         uint16_t r1 = (instr >> 6) & 0x7;
         reg[R_PC] = reg[r1]; /* JSRR */
     }
+    reg[R_R7] = temp;
     break;
 }
 ---


### PR DESCRIPTION
The previous implementation of JSRR here breaks for JSRR R7. Since R7 was immediately set to PC what happens when you RET is an infinite loop as you execute the subroutine again and again. The modifications here makes it more inline with the LC-3 ISA document as well.

This was a test case that broke my lc3 simulator complx long ago, and I thought I would share a better implementation :)